### PR TITLE
Check that requested node exists in response

### DIFF
--- a/check_puppetdb_nodes
+++ b/check_puppetdb_nodes
@@ -124,6 +124,11 @@ my $data = decode_json( $response->decoded_content );
 
 my $now = time();
 
+if ( defined( $np->opts->node ) and !@$data ) {
+    $np->add_message( CRITICAL,
+        $np->opts->node . " not found in puppetdb\n" );
+}
+
 foreach my $node (@$data) {
     my $name              = $node->{'name'};
     my $deactivated       = $node->{'deactivated'};


### PR DESCRIPTION
If the check of a specific node was requested, it should be a critical error if this node doesn't exist in the puppetdb.