### PR TITLE
Bugfix on premature exit and missing last report hash

### DIFF
--- a/check_puppetdb_nodes
+++ b/check_puppetdb_nodes
@@ -156,7 +156,7 @@ foreach my $node (@$data) {
     my $certname          = defined($node->{'certname'}) ? $node->{'certname'} : $node->{'name'} ;
     my $deactivated       = $node->{'deactivated'};
     my $catalog_timestamp = $node->{'catalog_timestamp'};
-    my $report_hash = $node->{'latest_report_hash'};
+    my $report_hash       = $node->{'latest_report_hash'};
     my $ts                = str2time($catalog_timestamp);
     if ( !defined $deactivated and ( !length $catalog_timestamp or !length $report_hash )) {
     	    $np->add_message( CRITICAL, 

--- a/check_puppetdb_nodes
+++ b/check_puppetdb_nodes
@@ -156,12 +156,13 @@ foreach my $node (@$data) {
     my $certname          = defined($node->{'certname'}) ? $node->{'certname'} : $node->{'name'} ;
     my $deactivated       = $node->{'deactivated'};
     my $catalog_timestamp = $node->{'catalog_timestamp'};
+    my $report_hash = $node->{'latest_report_hash'};
     my $ts                = str2time($catalog_timestamp);
-    if ( !defined $deactivated and !length $catalog_timestamp) {
+    if ( !defined $deactivated and ( !length $catalog_timestamp or !length $report_hash )) {
     	    $np->add_message( CRITICAL, 
     		    "$certname last run UNAVAILABLE\n" );
     }
-    if ( !defined $deactivated and length $catalog_timestamp) {
+    if ( !defined $deactivated and length $catalog_timestamp and $report_hash) {
         my $delta = ( $now - $ts );
         if ( $delta > ( $np->opts->critical * 60 ) ) {
             $np->add_message( CRITICAL,
@@ -171,7 +172,6 @@ foreach my $node (@$data) {
             $np->add_message( WARNING,
                 "$certname did not update since $catalog_timestamp\n" );
         }
-        my $report_hash = $node->{'latest_report_hash'};
 
         my %apiparameters = (
             3 => {
@@ -221,7 +221,7 @@ foreach my $node (@$data) {
                     foreach my $log (@$logs) {
                         my $tags = $log->{'tags'};
                         if ( grep(/^err$/, @$tags) ) { 
-                            $np->nagios_exit( WARNING, $log->{'message'} );
+                            $np->add_message( WARNING, "$certname, $log->{'message'}" );
                         }
                     }
                 }


### PR DESCRIPTION
Premature exit in casa of all nodes to be checked,
the nagios_exit caused it.

Moving $report_hash above, because may happens on
inherted environment that report hash do not exists
anymore while last run is still set long in the paste.

Example node:
```
 {
	"deactivated": null,
	"latest_report_hash": null,
	"facts_environment": "development",
	"cached_catalog_status": null,
	"report_environment": null,
	"latest_report_corrective_change": null,
	"catalog_environment": "development",
	"facts_timestamp": "2016-05-11T00:03:16.242Z",
	"latest_report_noop": null,
	"expired": null,
	"latest_report_noop_pending": null,
	"report_timestamp": null,
	"certname": "masqueraded.fqdn.com",
	"catalog_timestamp": "2016-05-11T00:03:20.789Z",
	"latest_report_status": null
}
```