### PR TITLE
Use Monitoring::Plugin instead of Nagios::Plugin that was removed from CPAN

### DIFF
--- a/check_puppetdb_nodes
+++ b/check_puppetdb_nodes
@@ -32,10 +32,10 @@ use strict;
 use warnings;
 use JSON;
 use LWP;
-use Nagios::Plugin;
+use Monitoring::Plugin;
 use Date::Parse;
 
-my $np = Nagios::Plugin->new(
+my $np = Monitoring::Plugin->new(
     usage => "Usage: %s [ -H|--hostname=<hostname>] "
       . "[ -p|--port=<port> ] [-s] [ -w|--warning=<minutes> ] "
       . "[ -c|--critical=<minutes> ] [ -W|--warnfails=<num> ] "


### PR DESCRIPTION
https://metacpan.org/pod/Nagios::Plugin reads "Removed from CPAN by request of
Nagios Enterprises, succeeded by Monitoring::Plugin".